### PR TITLE
fix inheritance with block-style nested routes

### DIFF
--- a/lib/Forward/Routes.pm
+++ b/lib/Forward/Routes.pm
@@ -28,7 +28,7 @@ sub initialize {
     my $self = shift;
 
     # block
-    my $code_ref = pop @_ if @_ && ref $_[-1] eq 'CODE';
+    $self->{code_ref} = pop @_ if @_ && ref $_[-1] eq 'CODE';
 
     # inherit
     $self->{_inherit_format} = 1;
@@ -41,7 +41,7 @@ sub initialize {
     $self->pattern->pattern($pattern) if defined $pattern;
 
     # Shortcut in case of chained API
-    return $self unless @_ || $code_ref;
+    return $self unless @_ || $self->{code_ref};
 
     # Remaining params
     my $params = ref $_[0] eq 'HASH' ? {%{$_[0]}} : {@_};
@@ -55,9 +55,6 @@ sub initialize {
     $self->to(delete $params->{to});
     $self->constraints(delete $params->{constraints});
     $self->resource_name(delete $params->{resource_name});
-
-    # after inheritance
-    $code_ref->($self) if $code_ref;
 
     return $self;
 }
@@ -207,6 +204,9 @@ sub add_child {
     $child->via(           [@{$self->{via}}]      ) if $self->{via}           && $child->_inherit_via;
     $child->namespace(     $self->{namespace}     ) if $self->{namespace}     && $child->_inherit_namespace;
     $child->app_namespace( $self->{app_namespace} ) if $self->{app_namespace} && $child->_inherit_app_namespace;
+
+    my $code_ref = delete $child->{code_ref};
+    $code_ref->($child) if $code_ref;
 
     return $child;
 }

--- a/t/nested_routes_block_style.t
+++ b/t/nested_routes_block_style.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 12;
+use Test::More tests => 13;
 use lib 'lib';
 use Forward::Routes;
 
@@ -51,7 +51,7 @@ is_deeply $m->[0]->params, {controller => 'Comment', action => 'show', author_na
 #############################################################################
 ### block style
 
-my $b = Forward::Routes->new;
+my $b = Forward::Routes->new->app_namespace('Root');
 
 $b->add_route('/authors', sub {
     my $authors = shift;
@@ -88,6 +88,7 @@ $b->add_route('/authors', sub {
 # tests
 $m = $b->match(get => '/authors');
 is_deeply $m->[0]->params, {controller => 'Author', action => 'index'};
+is $m->[0]->class, 'Root::Author';
 
 $m = $b->match(get => '/authors/steven');
 is_deeply $m->[0]->params, {controller => 'Author', action => 'show', author_name => 'steven'};


### PR DESCRIPTION
Namespaces weren't being inherited when using block-style nested routes.

This patch fixes it by delaying the call to the code ref until after it's added to the parent route, which is where the inheritance is handled.

Test for it is included.
